### PR TITLE
feat(macminixhci): restore USB boot device on Macmini7,1

### DIFF
--- a/macminixhci/README.md
+++ b/macminixhci/README.md
@@ -1,0 +1,57 @@
+# macminixhci
+
+Opt-in, beta workaround for missing USB devices on the tested Apple Macmini7,1
+(Intel Core i5-4278U, Intel `8086:9c31` xHCI at `0000:00:14.0`, subsystem
+`8086:7270`). Enable the addon and rebuild the loader before booting DSM.
+Initially offered only for apollolake; other CPUs and DSM platforms are untested.
+The CPU/PCI checks constrain applicability but are not a unique Apple identity.
+
+## Observed failure and recovery
+
+On Arc 4.0.0 (build 260907), DS918+ / DSM 7.4.1-90080 (kernel 4.4.302),
+a fresh installation repeatedly stopped at 55%. PAT checksum verification passed,
+but the updater could not mount `/dev/synoboot2` and ended with error 21.
+DSM enumerated only USB root hubs; the boot USB and `/dev/synoboot*` were missing.
+
+PCI configuration showed disabled routing despite nonzero supported-port masks:
+
+| Register | Offset | Observed value |
+| --- | --- | --- |
+| XUSB2PR | 0xD0 | 0x00000000 |
+| USB2PRM | 0xD4 | 0x000001FF |
+| USB3_PSSEN | 0xD8 | 0x00000000 |
+| USB3PRM | 0xDC | 0x0000000F |
+
+Writing USB3PRM to USB3_PSSEN, then USB2PRM to XUSB2PR, immediately restored USB
+enumeration and the boot partitions. Installation then completed successfully
+and DSM reached its welcome screen after reboot. The component that disabled
+routing has not been identified; this does not establish an Arc regression.
+
+## Behavior and scope
+
+The addon runs at `modules` and `patches`, using `xxd` available in the tested DSM
+installer. It follows the register sequence in Linux
+[`usb_enable_intel_xhci_ports()`](https://kernel.googlesource.com/pub/scm/linux/kernel/git/stable/linux-stable/+/v4.4/drivers/usb/host/pci-quirks.c).
+It accepts only the measured masks and routing values that are either zero or
+already equal to those masks. It verifies each write, leaves already enabled
+registers alone, and waits five seconds only after a change. An unexpected value
+or I/O error stops processing. A later failure can leave an earlier successful
+write in place; the addon reports the failure and does not attempt a rollback.
+
+DMI product names are spoofed in the tested DSM environment, so the guard uses
+the tested CPU and PCI identifiers. No driver replacement, MSI setting, disk
+partition, or persistent PCI firmware setting is involved. Disabling the addon
+and rebuilding removes the workaround from subsequent DSM boots.
+
+The original routing workaround was exercised on one physical machine. The
+additional fail-closed checks and readback verification in this submission have
+local fixture coverage, but this exact revised script has not been boot-tested
+on that machine. Wider hardware and cold-boot testing are still needed.
+
+## Local checks
+
+Run `sh -n macminixhci/install.sh` and
+`python3 -m unittest discover -s macminixhci/tests -v` from the repository root.
+The tests substitute command wrappers and a temporary PCI configuration file;
+they never access real PCI devices. Build with
+`./compile-addons.sh macminixhci` in the repository's build environment.

--- a/macminixhci/install.sh
+++ b/macminixhci/install.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env sh
+# SPDX-License-Identifier: GPL-3.0-only
+# Restore disabled Intel USB routing on the tested Macmini7,1 configuration.
+
+case "${1}" in modules|patches) ;; *) exit 0 ;; esac
+
+# DSM spoofs the DMI product name. Limit this opt-in workaround to the tested
+# CPU/controller combination instead of relying on that name.
+grep -q 'i5-4278U' /proc/cpuinfo || exit 0
+XHCI=/sys/bus/pci/devices/0000:00:14.0
+[ "$(cat "${XHCI}/vendor" 2>/dev/null)" = "0x8086" ] || exit 0
+[ "$(cat "${XHCI}/device" 2>/dev/null)" = "0x9c31" ] || exit 0
+[ "$(cat "${XHCI}/subsystem_vendor" 2>/dev/null)" = "0x8086" ] || exit 0
+[ "$(cat "${XHCI}/subsystem_device" 2>/dev/null)" = "0x7270" ] || exit 0
+CFG="${XHCI}/config"
+
+fail() {
+  echo "macminixhci: ${1}" >&2
+  exit 1
+}
+
+# xxd is available in the tested DSM installer; setpci is not.
+USB3_MASK="$(xxd -p -s 220 -l 4 "${CFG}")" || fail "cannot read USB3PRM"
+USB2_MASK="$(xxd -p -s 212 -l 4 "${CFG}")" || fail "cannot read USB2PRM"
+[ "${USB3_MASK}" = "0f000000" ] && [ "${USB2_MASK}" = "ff010000" ] ||
+  fail "unexpected USB routing masks; leaving controller unchanged"
+
+USB3_CURRENT="$(xxd -p -s 216 -l 4 "${CFG}")" || fail "cannot read USB3_PSSEN"
+USB2_CURRENT="$(xxd -p -s 208 -l 4 "${CFG}")" || fail "cannot read XUSB2PR"
+# Refuse partial, unknown, or truncated values before writing either register.
+case "${USB3_CURRENT}" in 00000000|"${USB3_MASK}") ;; *) fail "unexpected USB3 routing" ;; esac
+case "${USB2_CURRENT}" in 00000000|"${USB2_MASK}") ;; *) fail "unexpected USB2 routing" ;; esac
+
+CHANGED=false
+# As in Linux usb_enable_intel_xhci_ports(), enable USB3 before routing USB2.
+# These strings are raw little-endian bytes, not host-endian integers.
+if [ "${USB3_CURRENT}" != "${USB3_MASK}" ]; then
+  printf '000000d8: %s\n' "${USB3_MASK}" | xxd -r - "${CFG}" || fail "USB3 write failed"
+  USB3_CURRENT="$(xxd -p -s 216 -l 4 "${CFG}")" || fail "USB3 readback failed"
+  [ "${USB3_CURRENT}" = "${USB3_MASK}" ] || fail "USB3 readback mismatch"
+  CHANGED=true
+fi
+if [ "${USB2_CURRENT}" != "${USB2_MASK}" ]; then
+  printf '000000d0: %s\n' "${USB2_MASK}" | xxd -r - "${CFG}" || fail "USB2 write failed"
+  USB2_CURRENT="$(xxd -p -s 208 -l 4 "${CFG}")" || fail "USB2 readback failed"
+  [ "${USB2_CURRENT}" = "${USB2_MASK}" ] || fail "USB2 readback mismatch"
+  CHANGED=true
+fi
+if [ "${CHANGED}" = "true" ]; then
+  echo "macminixhci: restored Intel USB port routing"
+  sleep 5 # Allow USB enumeration before the installer accesses synoboot.
+fi
+exit 0

--- a/macminixhci/manifest.yml
+++ b/macminixhci/manifest.yml
@@ -1,0 +1,9 @@
+version: 1
+name: macminixhci
+description: "Restore USB boot device on Macmini7,1 (i5-4278U)"
+system: false
+beta: true
+all:
+  install-script: "install.sh"
+  copy: ""
+apollolake: true

--- a/macminixhci/tests/test_install.py
+++ b/macminixhci/tests/test_install.py
@@ -1,0 +1,197 @@
+"""Exercise the real shell script without accessing hardware (Python 3 + xxd)."""
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "install.sh"
+XXD = shutil.which("xxd")
+GREP = shutil.which("grep")
+WRAPPER = r'''
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+root = Path(os.environ["FIXTURE"])
+name = Path(sys.argv[0]).name
+args = sys.argv[1:]
+if name == "cat":
+    path = root / Path(args[0]).name
+    sys.stdout.write(path.read_text())
+elif name == "grep":
+    assert args[-1] == "/proc/cpuinfo"
+    args[-1] = str(root / "cpuinfo")
+    sys.exit(subprocess.call([os.environ["REAL_GREP"], *args]))
+elif name == "xxd":
+    assert args[-1] == "/sys/bus/pci/devices/0000:00:14.0/config"
+    args[-1] = str(root / "config")
+    if args[0] == "-r":
+        data = sys.stdin.read()
+        with (root / "writes").open("a") as log:
+            log.write(data)
+        offset = data.split(":")[0]
+        if offset == os.environ.get("FAIL_WRITE"):
+            sys.exit(1)
+        if offset == os.environ.get("IGNORE_WRITE"):
+            sys.exit(0)
+        sys.exit(subprocess.run([os.environ["REAL_XXD"], *args],
+                                input=data, text=True).returncode)
+    offset = args[args.index("-s") + 1]
+    if offset == os.environ.get("FAIL_READBACK") and (root / "writes").exists():
+        sys.exit(1)
+    if offset == os.environ.get("FAIL_READ"):
+        sys.exit(1)
+    if offset == os.environ.get("SHORT_READ"):
+        print("00")
+        sys.exit(0)
+    sys.exit(subprocess.call([os.environ["REAL_XXD"], *args]))
+elif name == "sleep":
+    (root / "slept").write_text(" ".join(args))
+else:
+    raise AssertionError(name)
+'''
+
+
+@unittest.skipUnless(XXD and GREP, "xxd and grep are required")
+class RoutingTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+        for command in ("cat", "grep", "xxd", "sleep"):
+            wrapper = self.bin / command
+            wrapper.write_text("#!" + sys.executable + "\n" + WRAPPER)
+            wrapper.chmod(0o755)
+        for name, value in {"cpuinfo": "model name : Intel Core i5-4278U CPU",
+                            "vendor": "0x8086", "device": "0x9c31",
+                            "subsystem_vendor": "0x8086",
+                            "subsystem_device": "0x7270"}.items():
+            (self.root / name).write_text(value + "\n")
+        self.initial = bytearray(256)
+        self.initial[0xD4:0xD8] = bytes.fromhex("ff010000")
+        self.initial[0xDC:0xE0] = bytes.fromhex("0f000000")
+        (self.root / "config").write_bytes(self.initial)
+        self.env = dict(os.environ, PATH=str(self.bin), FIXTURE=str(self.root),
+                        REAL_XXD=XXD, REAL_GREP=GREP)
+
+    def run_script(self, hook="modules", **env):
+        return subprocess.run(["/bin/sh", str(SCRIPT), hook],
+                              env=dict(self.env, **env), capture_output=True,
+                              text=True, timeout=15)
+
+    def writes(self):
+        log = self.root / "writes"
+        return log.read_text().splitlines() if log.exists() else []
+
+    def set_register(self, offset, value):
+        config = bytearray((self.root / "config").read_bytes())
+        config[offset:offset + 4] = bytes.fromhex(value)
+        (self.root / "config").write_bytes(config)
+
+    def assert_untouched(self):
+        self.assertEqual(self.writes(), [])
+        self.assertFalse((self.root / "slept").exists())
+
+    def test_restore_order_exact_bytes_and_idempotence(self):
+        result = self.run_script()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.writes(), ["000000d8: 0f000000", "000000d0: ff010000"])
+        expected = self.initial[:]
+        expected[0xD8:0xDC] = bytes.fromhex("0f000000")
+        expected[0xD0:0xD4] = bytes.fromhex("ff010000")
+        self.assertEqual((self.root / "config").read_bytes(), expected)
+        self.assertEqual((self.root / "slept").read_text(), "5")
+        (self.root / "writes").unlink()
+        (self.root / "slept").unlink()
+        self.assertEqual(self.run_script("patches").returncode, 0)
+        self.assert_untouched()
+
+    def test_patches_can_restore_independently(self):
+        self.assertEqual(self.run_script("patches").returncode, 0)
+        self.assertEqual(len(self.writes()), 2)
+
+    def test_other_hooks_do_nothing(self):
+        for hook in ("early", "late", "rcExit", ""):
+            self.assertEqual(self.run_script(hook).returncode, 0)
+        self.assert_untouched()
+
+    def test_hardware_guards(self):
+        for name in ("cpuinfo", "vendor", "device", "subsystem_vendor", "subsystem_device"):
+            with self.subTest(name=name):
+                path = self.root / name
+                original = path.read_text()
+                path.write_text("unsupported\n")
+                self.assertEqual(self.run_script().returncode, 0)
+                self.assert_untouched()
+                path.write_text(original)
+
+    def test_missing_xxd(self):
+        (self.bin / "xxd").unlink()
+        self.assertNotEqual(self.run_script().returncode, 0)
+        self.assert_untouched()
+
+    def test_unknown_masks_or_routing_fail_before_writes(self):
+        for offset in (0xD0, 0xD4, 0xD8, 0xDC):
+            with self.subTest(offset=offset):
+                (self.root / "config").write_bytes(self.initial)
+                self.set_register(offset, "01000000")
+                self.assertNotEqual(self.run_script().returncode, 0)
+                self.assert_untouched()
+
+    def test_failed_or_truncated_reads_fail_before_writes(self):
+        for offset in (208, 212, 216, 220):
+            for failure in ("FAIL_READ", "SHORT_READ"):
+                with self.subTest(offset=offset, failure=failure):
+                    self.assertNotEqual(self.run_script(**{failure: str(offset)}).returncode, 0)
+                    self.assert_untouched()
+
+    def test_usb3_failure_prevents_usb2_write(self):
+        for failure in ("FAIL_WRITE", "IGNORE_WRITE"):
+            with self.subTest(failure=failure):
+                (self.root / "writes").write_text("")
+                self.assertNotEqual(self.run_script(**{failure: "000000d8"}).returncode, 0)
+                self.assertEqual(self.writes(), ["000000d8: 0f000000"])
+                self.assertEqual((self.root / "config").read_bytes(), self.initial)
+                self.assertFalse((self.root / "slept").exists())
+
+    def test_usb2_failure_is_reported(self):
+        for failure in ("FAIL_WRITE", "IGNORE_WRITE"):
+            with self.subTest(failure=failure):
+                (self.root / "config").write_bytes(self.initial)
+                (self.root / "writes").write_text("")
+                self.assertNotEqual(self.run_script(**{failure: "000000d0"}).returncode, 0)
+                self.assertEqual(len(self.writes()), 2)
+                self.assertFalse((self.root / "slept").exists())
+
+    def test_readback_io_failure_stops_processing(self):
+        for offset, writes in ((216, 1), (208, 2)):
+            with self.subTest(offset=offset):
+                (self.root / "config").write_bytes(self.initial)
+                if (self.root / "writes").exists():
+                    (self.root / "writes").unlink()
+                result = self.run_script(FAIL_READBACK=str(offset))
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("readback failed", result.stderr)
+                self.assertEqual(len(self.writes()), writes)
+                self.assertFalse((self.root / "slept").exists())
+
+    def test_only_disabled_register_is_written(self):
+        for enabled, mask, write in ((0xD8, "0f000000", "000000d0: ff010000"),
+                                     (0xD0, "ff010000", "000000d8: 0f000000")):
+            with self.subTest(enabled=enabled):
+                (self.root / "config").write_bytes(self.initial)
+                (self.root / "writes").write_text("")
+                self.set_register(enabled, mask)
+                self.assertEqual(self.run_script().returncode, 0)
+                self.assertEqual(self.writes(), [write])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add an opt-in `macminixhci` beta addon for the tested Macmini7,1 / i5-4278U configuration, where disabled Intel xHCI port routing made the USB boot device disappear in DSM and blocked a fresh installation at 55%.

### Observed on hardware

- Arc 4.0.0, build 260907; DS918+ (apollolake), DSM 7.4.1-90080 / kernel 4.4.302.
- Intel xHCI `8086:9c31` at `0000:00:14.0`, subsystem `8086:7270`.
- PAT verification passed. USB root hubs were present, but the boot USB and `/dev/synoboot*` were absent:

```text
Pass checksum of /tmpData/upd@te
failed to mount boot device /dev/synoboot2 /tmp/bootmnt (errno:2)
Failed to mount boot partition
Failed to accomplish the update! (errno = 21)
```

XUSB2PR (0xD0) and USB3_PSSEN (0xD8) were both zero. Supported masks USB2PRM (0xD4) and USB3PRM (0xDC) were 0x1ff and 0x0f. Copying those masks to the corresponding routing registers, USB3 first, immediately restored USB enumeration and the boot partitions. Installation then succeeded and DSM reached its welcome screen after reboot. The component that cleared routing is not yet identified; this is a compatibility workaround, not a confirmed Arc regression.

### Implementation

- Follow the register sequence in Linux [`usb_enable_intel_xhci_ports()`](https://github.com/torvalds/linux/blob/v4.4/drivers/usb/host/pci-quirks.c#L867).
- Run at `modules` and `patches`; restrict availability to apollolake and guard the tested CPU, PCI/subsystem IDs, masks, and routing values. DSM spoofed the DMI product name on this machine, so DMI cannot be the guard.
- Use installer-available `xxd`; only restore disabled registers, verify every write, and wait for enumeration only after changing routing.
- Reject unknown/partial values and read errors before writing. Stop on write/readback failure. An earlier successful write can remain applied if a subsequent operation fails.
- Include reproduction notes and hardware-isolated tests. No compiled binaries or generated addon archives are committed.

### Validation and remaining work

- `sh -n macminixhci/install.sh` passed.
- `python3 -m unittest discover -s macminixhci/tests -v`: 11 tests passed, including guards, exact bytes/write order, repeated hooks, missing tooling, short/failed reads, partial routing, write failures, and readback failures.
- The unchanged `compile-addons.sh macminixhci` built the package in an isolated macOS directory using native yq in place of the bundled Linux executable. Extracted payload matches the source and has executable permissions; manifest flags verified.

The original workaround was tested on one physical Mac mini. On 2026-09-11, the owner additionally confirmed that rebooting works normally with the currently installed addon. This report does not establish that the exact revised PR script was deployed, or that a cold power cycle was tested. The added guards and readback checks in this revised submission have fixture coverage but have not been boot-tested on that machine. Ready for maintainer review. Hardware testing of the exact revised script, other CPUs/platforms, and repeated cold boots remains outstanding.
